### PR TITLE
Do not show unsupported versions into list-all

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -8,8 +8,8 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-if (echo "$ASDF_INSTALL_VERSION" | grep -E '^0\.[0-9]\.') || (echo "$ASDF_INSTALL_VERSION" | grep -E '^0\.1[0-5]\.'); then
-  fail "This plugin supports cargo-make version since 0.16.0 for simplicity. They changed release file naming since 0.15.1."
+if ! is_supporting_cargomake_version; then
+  fail "Supporting cargo-make versions since 0.16.0 or later"
 fi
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"

--- a/bin/list-all
+++ b/bin/list-all
@@ -8,4 +8,10 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-list_all_versions | sort_versions | xargs echo
+# If we would debug.
+#   diff <(list_all_versions) <(list_all_supporting_versions)
+
+# Shows only this plugin supporting versions.
+#   https://github.com/asdf-vm/asdf/blob/950e4172719cde107e9dfc2c8c38d88ee0d000ca/docs/plugins/create.md?plain=1#L9
+#   https://github.com/asdf-vm/asdf/blob/950e4172719cde107e9dfc2c8c38d88ee0d000ca/docs/plugins/create.md?plain=1#L32
+list_all_supporting_versions | sort_versions | xargs echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -8,6 +8,17 @@ TOOL_NAME="cargo-make"
 # NOTE: Both --help, --version options exist. Prefix should be `makers` or `cargo-make make`. However `makers` does not exist in older versions.
 TOOL_TEST="cargo-make make --version"
 
+# We would check after released 1.0.0+
+supporting_cargomake_version_pattern='^([1-9][0-9]{0,}|0)\.([2-9][0-9]|1[6-9])\.[0-9]{1,}$'
+
+filter_supporting_cargomake_versions() {
+  grep -E "$supporting_cargomake_version_pattern"
+}
+
+is_supporting_cargomake_version() {
+  echo "$ASDF_INSTALL_VERSION" | grep -qE "$supporting_cargomake_version_pattern"
+}
+
 fail() {
   echo -e "asdf-$TOOL_NAME: $*"
   exit 1
@@ -32,6 +43,10 @@ list_github_tags() {
 
 list_all_versions() {
   list_github_tags
+}
+
+list_all_supporting_versions() {
+  list_all_versions | filter_supporting_cargomake_versions
 }
 
 download_release() {


### PR DESCRIPTION
Imported from https://github.com/kachick/asdf-zigmod/tree/2ca351b278d58c88088dc4fd146cc6857ecf4567

```bash
diff <(list_all_versions) <(list_all_supporting_versions)
```

```diff
1,21d0
< 0.10.0
< 0.10.1
< 0.10.2
< 0.10.3
< 0.10.4
< 0.10.5
< 0.10.6
< 0.10.7
< 0.10.8
< 0.11.0
< 0.11.1
< 0.11.2
< 0.11.3
< 0.12.0
< 0.12.1
< 0.13.0
< 0.14.0
< 0.15.0
< 0.15.1
< 0.15.2
< 0.15.3
60,97d38
< 0.3.40
< 0.3.41
< 0.3.42
< 0.3.43
< 0.3.44
< 0.3.45
< 0.3.46
< 0.3.47
< 0.3.48
< 0.3.49
< 0.3.50
< 0.3.51
< 0.3.52
< 0.3.53
< 0.3.54
< 0.3.55
< 0.3.56
< 0.3.57
< 0.3.58
< 0.3.59
< 0.3.60
< 0.3.61
< 0.3.62
< 0.3.63
< 0.3.64
< 0.3.65
< 0.3.66
< 0.3.67
< 0.3.68
< 0.3.69
< 0.3.70
< 0.3.71
< 0.3.72
< 0.3.73
< 0.3.74
< 0.3.75
< 0.3.76
< 0.3.77
141d81
< 0.35.4-beta1
150,243d89
< 0.4.1
< 0.5.0
< 0.5.1
< 0.5.2
< 0.5.3
< 0.6.1
< 0.6.2
< 0.6.3
< 0.6.4
< 0.6.5
< 0.7.0
< 0.7.1
< 0.7.10
< 0.7.11
< 0.7.2
< 0.7.3
< 0.7.4
< 0.7.5
< 0.7.6
< 0.7.7
< 0.7.8
< 0.7.9
< 0.8.0
< 0.9.0
< 0.9.1
< 0.9.2
< 0.9.3
< 0.9.4
< 0.9.5
< 0.1.2
< 0.2.0
< 0.2.1
< 0.2.10
< 0.2.11
< 0.2.12
< 0.2.13
< 0.2.14
< 0.2.15
< 0.2.16
< 0.2.17
< 0.2.18
< 0.2.19
< 0.2.2
< 0.2.20
< 0.2.3
< 0.2.4
< 0.2.5
< 0.2.6
< 0.2.7
< 0.2.8
< 0.2.9
< 0.3.0
< 0.3.1
< 0.3.10
< 0.3.11
< 0.3.12
< 0.3.13
< 0.3.14
< 0.3.15
< 0.3.16
< 0.3.17
< 0.3.18
< 0.3.19
< 0.3.2
< 0.3.20
< 0.3.21
< 0.3.22
< 0.3.23
< 0.3.24
< 0.3.25
< 0.3.26
< 0.3.27
< 0.3.28
< 0.3.29
< 0.3.3
< 0.3.30
< 0.3.31
< 0.3.32
< 0.3.33
< 0.3.34
< 0.3.35
< 0.3.36
< 0.3.37
< 0.3.38
< 0.3.39
< 0.3.4
< 0.3.5
< 0.3.6
< 0.3.7
< 0.3.8
< 0.3.9
< 0.32.17-beta2
< 0.32.17-beta4
< 0.35.6-beta1
```