### PR TITLE
Enable faster macOS runner in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-latest-xl
         target:
           - tool-version: 'latest'
             command: 'makers --version && cargo-make make --version'

--- a/.github/workflows/rtx.yml
+++ b/.github/workflows/rtx.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-latest-xl
         target:
           - command: rtx x cargo-make@latest -- makers --version && rtx x cargo-make@latest -- cargo-make make --version
           - # makers does not exist


### PR DESCRIPTION
https://github.blog/changelog/2023-04-24-github-actions-faster-macos-runners-are-now-available-in-open-public-beta/